### PR TITLE
feat: implement environment variable management

### DIFF
--- a/src/composables/useEnvironment.ts
+++ b/src/composables/useEnvironment.ts
@@ -1,0 +1,45 @@
+import { computed } from 'vue';
+
+/**
+ * Composable for accessing environment variables
+ * Provides type-safe access to Vite environment variables
+ */
+export function useEnvironment() {
+  const firebaseConfig = computed(() => ({
+    apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
+    authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN,
+    projectId: import.meta.env.VITE_FIREBASE_PROJECT_ID,
+    storageBucket: import.meta.env.VITE_FIREBASE_STORAGE_BUCKET,
+    messagingSenderId: import.meta.env.VITE_FIREBASE_MESSAGING_SENDER_ID,
+    appId: import.meta.env.VITE_FIREBASE_APP_ID,
+    measurementId: import.meta.env.VITE_FIREBASE_MEASUREMENT_ID,
+  }));
+
+  const appConfig = computed(() => ({
+    name: import.meta.env.VITE_APP_NAME || 'PantryPilot',
+    version: import.meta.env.VITE_APP_VERSION || '1.0.0',
+    environment: import.meta.env.VITE_APP_ENV || 'development',
+  }));
+
+  const apiConfig = computed(() => ({
+    baseUrl: import.meta.env.VITE_API_BASE_URL || 'http://localhost:3000/api',
+    timeout: parseInt(import.meta.env.VITE_API_TIMEOUT || '10000'),
+  }));
+
+  const featureFlags = computed(() => ({
+    analytics: import.meta.env.VITE_ENABLE_ANALYTICS === 'true',
+    debugMode: import.meta.env.VITE_ENABLE_DEBUG_MODE === 'true',
+  }));
+
+  const isDevelopment = computed(() => import.meta.env.DEV);
+  const isProduction = computed(() => import.meta.env.PROD);
+
+  return {
+    firebaseConfig,
+    appConfig,
+    apiConfig,
+    featureFlags,
+    isDevelopment,
+    isProduction,
+  };
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,19 +1,33 @@
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import vue from '@vitejs/plugin-vue';
 import tailwindcss from '@tailwindcss/vite';
 import path from 'path';
 
 // https://vite.dev/config/
-export default defineConfig({
-  plugins: [vue(), tailwindcss()],
-  resolve: {
-    alias: {
-      '@': path.resolve(__dirname, './src'),
+export default defineConfig(({ mode }) => {
+  // Load env file based on `mode` in the current working directory.
+  // Set the third parameter to '' to load all env regardless of the `VITE_` prefix.
+  const env = loadEnv(mode, process.cwd(), '');
+  
+  return {
+    plugins: [vue(), tailwindcss()],
+    resolve: {
+      alias: {
+        '@': path.resolve(__dirname, './src'),
+      },
     },
-  },
-  server: {
-    port: 5001,
-    host: true,
-    strictPort: true,
-  },
+    server: {
+      port: parseInt(env.VITE_DEV_SERVER_PORT) || 5001,
+      host: env.VITE_DEV_SERVER_HOST || true,
+      strictPort: true,
+    },
+    // Define global constants for build-time replacement
+    define: {
+      __APP_VERSION__: JSON.stringify(env.VITE_APP_VERSION || '1.0.0'),
+      __APP_NAME__: JSON.stringify(env.VITE_APP_NAME || 'PantryPilot'),
+      __APP_ENV__: JSON.stringify(env.VITE_APP_ENV || 'development'),
+    },
+    // Environment variables are automatically available via import.meta.env
+    // No additional configuration needed for VITE_ prefixed variables
+  };
 });


### PR DESCRIPTION
- Add .env.example with Firebase config placeholders
- Update vite.config.ts to use loadEnv for environment variables
- Add useEnvironment composable for type-safe env access
- Verify .gitignore already excludes .env* files
- Test build process works correctly

Closes #8